### PR TITLE
New version: Obfuscatee v0.1.1

### DIFF
--- a/O/Obfuscatee/Versions.toml
+++ b/O/Obfuscatee/Versions.toml
@@ -1,2 +1,5 @@
 ["0.1.0"]
 git-tree-sha1 = "1efb4c5b19688594d3bd4e13dd5f018eb1091138"
+
+["0.1.1"]
+git-tree-sha1 = "7e359f19345cd6c8125baa681aab954263deb56b"


### PR DESCRIPTION
UUID: 4b331413-18b5-5698-88d1-0abf3b5dfc34
Repo: https://github.com/sisl/Obfuscatee.jl
Tree: 7e359f19345cd6c8125baa681aab954263deb56b

Registrator tree SHA: e7f59bec82a47801360f80caa1bf3c5ff058c157