### PR TITLE
New version: StanfordAA228V v0.1.5

### DIFF
--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "35fbea65a30949027814c01ca8d248b697ff82a7"
 
 ["0.1.4"]
 git-tree-sha1 = "46149c1ddd9e8b7cefd699993555dea42b90f084"
+
+["0.1.5"]
+git-tree-sha1 = "9b65c7f1ebfd7ae20dc9f9a7fbd1c61d7aa3691c"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: git@github.com:sisl/StanfordAA228V.jl.git
Tree: 9b65c7f1ebfd7ae20dc9f9a7fbd1c61d7aa3691c

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1