### PR TITLE
New version: StanfordAA228V v0.1.6

### DIFF
--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -15,3 +15,6 @@ git-tree-sha1 = "46149c1ddd9e8b7cefd699993555dea42b90f084"
 
 ["0.1.5"]
 git-tree-sha1 = "9b65c7f1ebfd7ae20dc9f9a7fbd1c61d7aa3691c"
+
+["0.1.6"]
+git-tree-sha1 = "1e927c52d6cc8e1a5882d66815fd882c111486cb"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: git@github.com:sisl/StanfordAA228V.jl.git
Tree: 1e927c52d6cc8e1a5882d66815fd882c111486cb

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1