### PR TITLE
New version: StanfordAA228V v0.1.8

### DIFF
--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -21,3 +21,6 @@ git-tree-sha1 = "1e927c52d6cc8e1a5882d66815fd882c111486cb"
 
 ["0.1.7"]
 git-tree-sha1 = "2bca56c6a739c6c6c4cf8360350d13b6b3279aca"
+
+["0.1.8"]
+git-tree-sha1 = "24a9dbdc0650297c9f919fe38fa7d886a186936d"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: git@github.com:sisl/StanfordAA228V.jl.git
Tree: 24a9dbdc0650297c9f919fe38fa7d886a186936d

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1