### PR TITLE
New version: StanfordAA228V v0.1.9

### DIFF
--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -24,3 +24,6 @@ git-tree-sha1 = "2bca56c6a739c6c6c4cf8360350d13b6b3279aca"
 
 ["0.1.8"]
 git-tree-sha1 = "24a9dbdc0650297c9f919fe38fa7d886a186936d"
+
+["0.1.9"]
+git-tree-sha1 = "cd28ceeb3a1e89d8c1586cba3b9c377da0151733"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: https://github.com/sisl/StanfordAA228V.jl.git
Tree: cd28ceeb3a1e89d8c1586cba3b9c377da0151733

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1