### PR TITLE
New version: StanfordAA228V v0.1.18

### DIFF
--- a/S/StanfordAA228V/Compat.toml
+++ b/S/StanfordAA228V/Compat.toml
@@ -33,6 +33,10 @@ ProgressLogging = "0.1.4 - 0.1"
 ["0.1.16 - 0"]
 LazySets = "3"
 
+["0.1.18 - 0"]
+Downloads = "1.6.0 - 1"
+TOML = "1.0.3 - 1"
+
 ["0.1.2 - 0"]
 SignalTemporalLogic = ["0.1", "1"]
 

--- a/S/StanfordAA228V/Deps.toml
+++ b/S/StanfordAA228V/Deps.toml
@@ -26,3 +26,7 @@ ProgressLogging = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 
 ["0.1.16 - 0"]
 LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
+
+["0.1.18 - 0"]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -51,3 +51,6 @@ git-tree-sha1 = "b240b8a46d44d24d98cd0eab1f692c1259a1af31"
 
 ["0.1.17"]
 git-tree-sha1 = "e31b27164735dedc42dd0350676219ee6f1dde61"
+
+["0.1.18"]
+git-tree-sha1 = "bed207f928c5f4824e6f17f0ea32138b81e28026"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: https://github.com/sisl/StanfordAA228V.jl.git
Tree: bed207f928c5f4824e6f17f0ea32138b81e28026

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1