### PR TITLE
New version: StanfordAA228V v0.1.21

### DIFF
--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -60,3 +60,6 @@ git-tree-sha1 = "e46052dbc617bef1389267fee8f2ce0ecd2ff8e6"
 
 ["0.1.20"]
 git-tree-sha1 = "a57ca3e694c9ea7be08a3ba570a04971dad204f6"
+
+["0.1.21"]
+git-tree-sha1 = "2a9663643b73c2bcf239707eb679803710ed396c"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: https://github.com/sisl/StanfordAA228V.jl.git
Tree: 2a9663643b73c2bcf239707eb679803710ed396c

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1