### PR TITLE
New version: StanfordAA228V v0.1.23

### DIFF
--- a/S/StanfordAA228V/Compat.toml
+++ b/S/StanfordAA228V/Compat.toml
@@ -40,5 +40,9 @@ TOML = "1.0.3 - 1"
 ["0.1.2 - 0"]
 SignalTemporalLogic = ["0.1", "1"]
 
+["0.1.23 - 0"]
+Distances = "0.10.12 - 0.10"
+Interpolations = "0.15.1 - 0.15"
+
 ["0.1.3 - 0"]
 LinearAlgebra = "1"

--- a/S/StanfordAA228V/Deps.toml
+++ b/S/StanfordAA228V/Deps.toml
@@ -30,3 +30,7 @@ LazySets = "b4f0291d-fe17-52bc-9479-3d1a343d9043"
 ["0.1.18 - 0"]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+["0.1.23 - 0"]
+Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"

--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -66,3 +66,6 @@ git-tree-sha1 = "2a9663643b73c2bcf239707eb679803710ed396c"
 
 ["0.1.22"]
 git-tree-sha1 = "5376632ae8604432fd7c8ce7308edf70950c1da8"
+
+["0.1.23"]
+git-tree-sha1 = "f981afcdd7bdea2601b181fb044001680cca8247"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: https://github.com/sisl/StanfordAA228V.jl.git
Tree: f981afcdd7bdea2601b181fb044001680cca8247

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1