### PR TITLE
New version: StanfordAA228V v0.1.26

### DIFF
--- a/S/StanfordAA228V/Versions.toml
+++ b/S/StanfordAA228V/Versions.toml
@@ -75,3 +75,6 @@ git-tree-sha1 = "01f5081ce23b889dd9c804ee3a5ae38288ca1831"
 
 ["0.1.25"]
 git-tree-sha1 = "758b0f1666ca15b1b3d647674da637263a4a91e9"
+
+["0.1.26"]
+git-tree-sha1 = "9b119ac1adb634faabfa191268091479ff8353e3"


### PR DESCRIPTION
UUID: 6f6e590e-f8c2-4a21-9268-94576b9fb3b1
Repo: https://github.com/sisl/StanfordAA228V.jl.git
Tree: 9b119ac1adb634faabfa191268091479ff8353e3

Registrator tree SHA: c0ac28884fab9ae94ed8cf3448aa950afc2ff9c1